### PR TITLE
Category,Cardテーブルの作成＋APIの追加

### DIFF
--- a/apis/bases/__init__.py
+++ b/apis/bases/__init__.py
@@ -1,1 +1,1 @@
-from . import base, user, channel, message
+from . import base, user, channel, message, card

--- a/apis/bases/__init__.py
+++ b/apis/bases/__init__.py
@@ -1,1 +1,1 @@
-from . import base, user, channel, message, card
+from . import base, user, channel, message, card ,category

--- a/apis/bases/card.py
+++ b/apis/bases/card.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, String, ForeignKey, Date
 from sqlalchemy.dialects.mysql import INTEGER as Integer
 from apis.bases.base import Base
-# from apis.bases.category import Category #別途作成するcategory.pyからCategoryクラスをインポート（Category.idがFKとなる）
+from apis.bases.category import Category #別途作成するcategory.pyからCategoryクラスをインポート（Category.idがFKとなる）
 # from apis.bases.color import Color #別途作成するcolor.pyからColorクラスをインポート（Color.idがFKとなる）
 
 class Card(Base):
@@ -9,7 +9,7 @@ class Card(Base):
     __table_args__ = {"extend_existing": True}  # 既存テーブルの再定義を認める
     card_id = Column(String(36), primary_key=True)
     card_pos = Column(Integer(unsigned=True))
-    col_id = Column(String(36), nullable=False) #あとで「ForeignKey(Category.id)」を追加
+    col_id = Column(String(36), ForeignKey(Category.col_id) ,nullable=False)
     card_name = Column(String(255), unique=True, nullable=False, index=True)
     input_date = Column(Date, nullable=False)
     due_date = Column(Date, nullable=False)

--- a/apis/bases/card.py
+++ b/apis/bases/card.py
@@ -1,18 +1,17 @@
-from sqlalchemy import Column, String, ForeignKey, Date #※サンプルから変更なし
-from sqlalchemy.dialects.mysql import INTEGER as Integer #※サンプルから変更なし
-from apis.bases.base import Base #※サンプルから変更なし
+from sqlalchemy import Column, String, ForeignKey, Date
+from sqlalchemy.dialects.mysql import INTEGER as Integer
+from apis.bases.base import Base
 # from apis.bases.category import Category #別途作成するcategory.pyからCategoryクラスをインポート（Category.idがFKとなる）
 # from apis.bases.color import Color #別途作成するcolor.pyからColorクラスをインポート（Color.idがFKとなる）
 
 class Card(Base):
     __tablename__ = "cards"  # テーブル名をcardsと指定 __tablename__はsqlalchemyの特別な変数
-    __table_args__ = {"extend_existing": True}  # 既存テーブルの再定義を認める。※サンプルから変更なし
-    id = Column(
-        Integer(unsigned=True), autoincrement=True, primary_key=True, index=True
-    ) #カードID
-    category_id = Column(Integer(unsigned=True), nullable=False) #カテゴリID　あとで「ForeignKey(Category.id)」を追加
-    color_id = Column(Integer(unsigned=True), nullable=False) #色ID　あとで「ForeignKey(Color.id)」を追加
-    name = Column(String(255), unique=True, nullable=False, index=True) #カード名
-    position = Column(Integer(unsigned=True)) #カードの位置
-    due_date = Column(Date, nullable=False) #期限
-    detail = Column(String(255), nullable=True) #カードの説明
+    __table_args__ = {"extend_existing": True}  # 既存テーブルの再定義を認める
+    card_id = Column(String(36), primary_key=True)
+    card_pos = Column(Integer(unsigned=True))
+    col_id = Column(String(36), nullable=False) #あとで「ForeignKey(Category.id)」を追加
+    card_name = Column(String(255), unique=True, nullable=False, index=True)
+    input_date = Column(Date, nullable=False)
+    due_date = Column(Date, nullable=False)
+    color = Column(String(10), nullable=False) #色ID　あとで「ForeignKey(Color.id)」を追加
+    description = Column(String(255), nullable=True)

--- a/apis/bases/card.py
+++ b/apis/bases/card.py
@@ -1,8 +1,8 @@
 from sqlalchemy import Column, String, ForeignKey, Date #※サンプルから変更なし
 from sqlalchemy.dialects.mysql import INTEGER as Integer #※サンプルから変更なし
 from apis.bases.base import Base #※サンプルから変更なし
-from apis.bases.category import Category #別途作成するcategory.pyからCategoryクラスをインポート（Category.idがFKとなる）
-from apis.bases.color import Color #別途作成するcolor.pyからColorクラスをインポート（Color.idがFKとなる）
+# from apis.bases.category import Category #別途作成するcategory.pyからCategoryクラスをインポート（Category.idがFKとなる）
+# from apis.bases.color import Color #別途作成するcolor.pyからColorクラスをインポート（Color.idがFKとなる）
 
 class Card(Base):
     __tablename__ = "cards"  # テーブル名をcardsと指定 __tablename__はsqlalchemyの特別な変数
@@ -10,8 +10,8 @@ class Card(Base):
     id = Column(
         Integer(unsigned=True), autoincrement=True, primary_key=True, index=True
     ) #カードID
-    category_id = Column(Integer(unsigned=True), ForeignKey(Category.id), nullable=False) #カテゴリID
-    color_id = Column(Integer(unsigned=True), ForeignKey(Color.id), nullable=False) #色ID
+    category_id = Column(Integer(unsigned=True), nullable=False) #カテゴリID　あとで「ForeignKey(Category.id)」を追加
+    color_id = Column(Integer(unsigned=True), nullable=False) #色ID　あとで「ForeignKey(Color.id)」を追加
     name = Column(String(255), unique=True, nullable=False, index=True) #カード名
     position = Column(Integer(unsigned=True)) #カードの位置
     due_date = Column(Date, nullable=False) #期限

--- a/apis/bases/card.py
+++ b/apis/bases/card.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, String, ForeignKey, Date #※サンプルから変更なし
+from sqlalchemy.dialects.mysql import INTEGER as Integer #※サンプルから変更なし
+from apis.bases.base import Base #※サンプルから変更なし
+from apis.bases.category import Category #別途作成するcategory.pyからCategoryクラスをインポート（Category.idがFKとなる）
+from apis.bases.color import Color #別途作成するcolor.pyからColorクラスをインポート（Color.idがFKとなる）
+
+class Card(Base):
+    __tablename__ = "cards"  # テーブル名をcardsと指定 __tablename__はsqlalchemyの特別な変数
+    __table_args__ = {"extend_existing": True}  # 既存テーブルの再定義を認める。※サンプルから変更なし
+    id = Column(
+        Integer(unsigned=True), autoincrement=True, primary_key=True, index=True
+    ) #カードID
+    category_id = Column(Integer(unsigned=True), ForeignKey(Category.id), nullable=False) #カテゴリID
+    color_id = Column(Integer(unsigned=True), ForeignKey(Color.id), nullable=False) #色ID
+    name = Column(String(255), unique=True, nullable=False, index=True) #カード名
+    position = Column(Integer(unsigned=True)) #カードの位置
+    due_date = Column(Date, nullable=False) #期限
+    abstract = Column(String(255), nullable=True) #カードの説明

--- a/apis/bases/card.py
+++ b/apis/bases/card.py
@@ -15,4 +15,4 @@ class Card(Base):
     name = Column(String(255), unique=True, nullable=False, index=True) #カード名
     position = Column(Integer(unsigned=True)) #カードの位置
     due_date = Column(Date, nullable=False) #期限
-    abstract = Column(String(255), nullable=True) #カードの説明
+    detail = Column(String(255), nullable=True) #カードの説明

--- a/apis/bases/card.py
+++ b/apis/bases/card.py
@@ -1,7 +1,8 @@
 from sqlalchemy import Column, String, ForeignKey, Date
 from sqlalchemy.dialects.mysql import INTEGER as Integer
 from apis.bases.base import Base
-from apis.bases.category import Category #別途作成するcategory.pyからCategoryクラスをインポート（Category.idがFKとなる）
+from apis.bases.category import Category
+from apis.bases.user import User
 # from apis.bases.color import Color #別途作成するcolor.pyからColorクラスをインポート（Color.idがFKとなる）
 
 class Card(Base):
@@ -10,6 +11,7 @@ class Card(Base):
     card_id = Column(String(36), primary_key=True)
     card_pos = Column(Integer(unsigned=True))
     col_id = Column(String(36), ForeignKey(Category.col_id) ,nullable=False)
+    uid = Column(String(36), ForeignKey(User.uid), nullable=False)
     card_name = Column(String(255), unique=True, nullable=False, index=True)
     input_date = Column(Date, nullable=False)
     due_date = Column(Date, nullable=False)

--- a/apis/bases/category.py
+++ b/apis/bases/category.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, String, ForeignKey, Date
+from sqlalchemy.dialects.mysql import INTEGER as Integer
+from apis.bases.base import Base
+
+class Category(Base):
+    __tablename__ = "categories"  # テーブル名をcategoriesと指定 __tablename__はsqlalchemyの特別な変数
+    __table_args__ = {"extend_existing": True}  # 既存テーブルの再定義を認める
+    col_id = Column(String(36), primary_key=True)
+    col_pos = Column(Integer(unsigned=True))
+    col_name = Column(String(255), unique=True, nullable=False, index=True)
+    description = Column(String(255), nullable=True)

--- a/apis/bases/category.py
+++ b/apis/bases/category.py
@@ -1,11 +1,13 @@
 from sqlalchemy import Column, String, ForeignKey, Date
 from sqlalchemy.dialects.mysql import INTEGER as Integer
 from apis.bases.base import Base
+from apis.bases.user import User
 
 class Category(Base):
     __tablename__ = "categories"  # テーブル名をcategoriesと指定 __tablename__はsqlalchemyの特別な変数
     __table_args__ = {"extend_existing": True}  # 既存テーブルの再定義を認める
     col_id = Column(String(36), primary_key=True)
     col_pos = Column(Integer(unsigned=True))
+    uid = Column(String(36), ForeignKey(User.uid), nullable=False)
     col_name = Column(String(255), unique=True, nullable=False, index=True)
     description = Column(String(255), nullable=True)

--- a/apis/main.py
+++ b/apis/main.py
@@ -14,6 +14,7 @@ from .routers.getmessages import view as view9
 from .routers.getcards import view as view10
 from .routers.getcategories import view as view11
 from .routers.addcard import view as view12
+from .routers.addcategory import view as view13
 
 app = FastAPI(docs_url="/docs", redoc_url="/redoc")
 
@@ -49,5 +50,5 @@ async def shutdown_logic():
 
 app.router.lifespan_context = app_lifespan
 
-for v in [view1, view2, view3, view4, view5, view6, view7, view8, view9, view10, view11, view12]:
+for v in [view1, view2, view3, view4, view5, view6, view7, view8, view9, view10, view11, view12, view13]:
     app.include_router(v.router)

--- a/apis/main.py
+++ b/apis/main.py
@@ -11,6 +11,7 @@ from .routers.delmessage import view as view6
 from .routers.delchannel import view as view7
 from .routers.getchannels import view as view8
 from .routers.getmessages import view as view9
+from .routers.getcards import view as view10
 
 app = FastAPI(docs_url="/docs", redoc_url="/redoc")
 
@@ -46,5 +47,5 @@ async def shutdown_logic():
 
 app.router.lifespan_context = app_lifespan
 
-for v in [view1, view2, view3, view4, view5, view6, view7, view8, view9]:
+for v in [view1, view2, view3, view4, view5, view6, view7, view8, view9, view10]:
     app.include_router(v.router)

--- a/apis/main.py
+++ b/apis/main.py
@@ -13,6 +13,7 @@ from .routers.getchannels import view as view8
 from .routers.getmessages import view as view9
 from .routers.getcards import view as view10
 from .routers.getcategories import view as view11
+from .routers.addcard import view as view12
 
 app = FastAPI(docs_url="/docs", redoc_url="/redoc")
 
@@ -48,5 +49,5 @@ async def shutdown_logic():
 
 app.router.lifespan_context = app_lifespan
 
-for v in [view1, view2, view3, view4, view5, view6, view7, view8, view9, view10, view11]:
+for v in [view1, view2, view3, view4, view5, view6, view7, view8, view9, view10, view11, view12]:
     app.include_router(v.router)

--- a/apis/main.py
+++ b/apis/main.py
@@ -12,6 +12,7 @@ from .routers.delchannel import view as view7
 from .routers.getchannels import view as view8
 from .routers.getmessages import view as view9
 from .routers.getcards import view as view10
+from .routers.getcategories import view as view11
 
 app = FastAPI(docs_url="/docs", redoc_url="/redoc")
 
@@ -47,5 +48,5 @@ async def shutdown_logic():
 
 app.router.lifespan_context = app_lifespan
 
-for v in [view1, view2, view3, view4, view5, view6, view7, view8, view9, view10]:
+for v in [view1, view2, view3, view4, view5, view6, view7, view8, view9, view10, view11]:
     app.include_router(v.router)

--- a/apis/routers/addcard/model.py
+++ b/apis/routers/addcard/model.py
@@ -1,0 +1,42 @@
+from fastapi import status, HTTPException
+from pydantic import BaseModel
+from .schema import Request, Response, TokenData, Data
+from apis.services.authfunctions import database
+from apis.bases.card import Card    
+
+
+class Model(BaseModel):
+    async def exec(self, body: Request, token: TokenData) -> Response:
+        # loginしていない場合、拒否する。
+        if not token:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+            )
+
+        # Channelテーブルに挿入するクエリ作成
+        query = Card.__table__.insert().values(
+            card_id=body.card_id,
+            card_pos=body.card_pos,
+            col_id=body.col_id,
+            uid=token.uid,
+            card_name=body.card_name,
+            input_date=body.input_date,
+            due_date=body.due_date,
+            color=body.color,
+            description=body.description
+        )
+        # テーブル更新
+        await database.execute(query)
+
+        dt = Data(
+            card_id=body.card_id,
+            card_pos=body.card_pos,
+            col_id=body.col_id,
+            uid=token.uid,
+            card_name=body.card_name,
+            input_date=body.input_date,
+            due_date=body.due_date,
+            color=body.color,
+            description=body.description
+        )
+        return Response(status=1, data=dt)

--- a/apis/routers/addcard/model.py
+++ b/apis/routers/addcard/model.py
@@ -13,7 +13,7 @@ class Model(BaseModel):
                 status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
             )
 
-        # Channelテーブルに挿入するクエリ作成
+        # Cardテーブルに挿入するクエリ作成
         query = Card.__table__.insert().values(
             card_id=body.card_id,
             card_pos=body.card_pos,

--- a/apis/routers/addcard/schema.py
+++ b/apis/routers/addcard/schema.py
@@ -1,0 +1,57 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import date
+
+
+class TokenData(BaseModel):
+    uid: str = Field(..., title="デコードされたtoken", description="cookieから取得したtoken一式")
+
+
+#カードテーブルの要素のうち以下をフロントから受け取る（uidはtokenからログイン中のユーザーidを取得）
+class Request(BaseModel):
+    card_id: str = Field(..., title="カードid", description="カードのID(ハッシュ値)")
+    card_pos: int = Field(..., title="カードの位置", description="カテゴリ内でのカードの位置を示す番号")
+    col_id: str = Field(..., title="カテゴリid", description="カテゴリのID(ハッシュ値)")
+    card_name: str = Field(..., title="カード名", description="カードの名前(タスク名)")
+    input_date: date = Field(..., title="作成日", description="カードの作成日")
+    due_date: date = Field(..., title="期限", description="タスクの期限")
+    color: str = Field(..., title="色id", description="色のid")
+    description: str = Field(None, title="カードの説明", description="カードの説明")
+
+
+RequestExample = {
+    "card_id": "3d9tbZoYUBFxXZpuXpB3DtMLdDf5o2rEaMT7",
+    "card_pos": 1,
+    "col_id": "vTwmtekFyxmisAnwJeiDXAihRRKLvQ2kMyRb",
+    "card_name": "中間発表資料を作成する",
+    "input_date": "2024-02-19",
+    "due_date": "2024-02-19",
+    "color": "color1",
+    "description": "Canvaで編集する"
+}
+
+
+#作成したカードの情報（カードテーブルの要素の全て）を返す
+class Data(BaseModel):
+    card_id: str = Field(..., title="カードid", description="カードのID(ハッシュ値)")
+    card_pos: int = Field(..., title="カードの位置", description="カテゴリ内でのカードの位置を示す番号")
+    col_id: str = Field(..., title="カテゴリid", description="カテゴリのID(ハッシュ値)")
+    uid: str = Field(..., title="ユーザーid", description="カードの作成者のID")
+    card_name: str = Field(..., title="カード名", description="カードの名前(タスク名)")
+    input_date: date = Field(..., title="作成日", description="カードの作成日")
+    due_date: date = Field(..., title="期限", description="タスクの期限")
+    color: str = Field(..., title="色id", description="色のid")
+    description: str = Field(None, title="カードの説明", description="カードの説明")
+
+
+class Response(BaseModel):
+    status: int = Field(
+        ...,
+        title="ステータス",
+        description="正しい場合1、不正の場合0",
+    )
+    data: Optional[Data] = Field(None, title="作成したカードの情報")
+
+
+#必要に応じて後で作成
+ResponseExamples = {}

--- a/apis/routers/addcard/schema.py
+++ b/apis/routers/addcard/schema.py
@@ -24,7 +24,7 @@ RequestExample = {
     "card_pos": 1,
     "col_id": "vTwmtekFyxmisAnwJeiDXAihRRKLvQ2kMyRb",
     "card_name": "中間発表資料を作成する",
-    "input_date": "2024-02-19",
+    "input_date": "2024-02-01",
     "due_date": "2024-02-19",
     "color": "color1",
     "description": "Canvaで編集する"

--- a/apis/routers/addcard/view.py
+++ b/apis/routers/addcard/view.py
@@ -1,0 +1,24 @@
+from fastapi import Depends, APIRouter, status
+from apis.services.authfunctions import get_current_user
+from .schema import Request, RequestExample, Response, ResponseExamples, TokenData
+from .model import Model
+from ..endpoints import AddCard as ep
+
+router = APIRouter()
+
+
+@router.post(
+    ep.endpoint,
+    summary=ep.summary,
+    description=ep.description,
+    status_code=status.HTTP_200_OK,
+    response_model=Response,
+    responses=ResponseExamples,
+    response_model_exclude_unset=True,
+    response_model_exclude_none=True,
+)
+async def get_payloads(
+    body: Request = RequestExample, token: TokenData = Depends(get_current_user)
+):
+    res = await Model().exec(body, token)
+    return res

--- a/apis/routers/addcategory/model.py
+++ b/apis/routers/addcategory/model.py
@@ -1,0 +1,34 @@
+from fastapi import status, HTTPException
+from pydantic import BaseModel
+from .schema import Request, Response, TokenData, Data
+from apis.services.authfunctions import database
+from apis.bases.category import Category
+
+
+class Model(BaseModel):
+    async def exec(self, body: Request, token: TokenData) -> Response:
+        # loginしていない場合、拒否する。
+        if not token:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+            )
+
+        # Categoryテーブルに挿入するクエリ作成
+        query = Category.__table__.insert().values(
+            col_id=body.col_id,
+            col_pos=body.col_pos,
+            uid=token.uid,
+            col_name=body.col_name,
+            description=body.description
+        )
+        # テーブル更新
+        await database.execute(query)
+
+        dt = Data(
+            col_id=body.col_id,
+            col_pos=body.col_pos,
+            uid=token.uid,
+            col_name=body.col_name,
+            description=body.description
+        )
+        return Response(status=1, data=dt)

--- a/apis/routers/addcategory/schema.py
+++ b/apis/routers/addcategory/schema.py
@@ -1,0 +1,39 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+
+
+class TokenData(BaseModel):
+    uid: str = Field(..., title="デコードされたtoken", description="cookieから取得したtoken一式")
+
+
+#カテゴリテーブルの要素のうち以下をフロントから受け取る（uidはtokenからログイン中のユーザーidを取得）
+class Request(BaseModel):
+    col_id: str = Field(..., title="カテゴリid", description="カテゴリのID(ハッシュ値)")
+    col_pos: int = Field(..., title="カテゴリの位置", description="カテゴリの位置を示す番号")
+    col_name: str = Field(..., title="カテゴリ名", description="カテゴリの名前(未着手／完了などのステータス名)")
+    description: str = Field(None, title="カテゴリの説明", description="カテゴリの説明")
+
+
+RequestExample = {}
+
+
+#作成したカテゴリの情報（カテゴリテーブルの要素の全て）を返す
+class Data(BaseModel):
+    col_id: str = Field(..., title="カテゴリid", description="カテゴリのID(ハッシュ値)")
+    col_pos: int = Field(..., title="カテゴリの位置", description="カテゴリの位置を示す番号")
+    uid: str = Field(..., title="ユーザーid", description="カードの作成者のID")
+    col_name: str = Field(..., title="カテゴリ名", description="カテゴリの名前(未着手／完了などのステータス名)")
+    description: str = Field(None, title="カテゴリの説明", description="カテゴリの説明")
+
+
+class Response(BaseModel):
+    status: int = Field(
+        ...,
+        title="ステータス",
+        description="正しい場合1、不正の場合0",
+    )
+    data: Optional[Data] = Field(None, title="作成したカテゴリの情報")
+
+
+#必要に応じて後で作成
+ResponseExamples = {}

--- a/apis/routers/addcategory/schema.py
+++ b/apis/routers/addcategory/schema.py
@@ -14,7 +14,12 @@ class Request(BaseModel):
     description: str = Field(None, title="カテゴリの説明", description="カテゴリの説明")
 
 
-RequestExample = {}
+RequestExample = {
+    "col_id": "vTwmtekFyxmisAnwJeiDXAihRRKLvQ2kMyRb",
+    "col_pos": 1,
+    "col_name": "未着手",
+    "description": "まだ手がつけられていないもの"
+}
 
 
 #作成したカテゴリの情報（カテゴリテーブルの要素の全て）を返す

--- a/apis/routers/addcategory/view.py
+++ b/apis/routers/addcategory/view.py
@@ -1,0 +1,24 @@
+from fastapi import Depends, APIRouter, status
+from apis.services.authfunctions import get_current_user
+from .schema import Request, RequestExample, Response, ResponseExamples, TokenData
+from .model import Model
+from ..endpoints import AddCategory as ep
+
+router = APIRouter()
+
+
+@router.post(
+    ep.endpoint,
+    summary=ep.summary,
+    description=ep.description,
+    status_code=status.HTTP_200_OK,
+    response_model=Response,
+    responses=ResponseExamples,
+    response_model_exclude_unset=True,
+    response_model_exclude_none=True,
+)
+async def get_payloads(
+    body: Request = RequestExample, token: TokenData = Depends(get_current_user)
+):
+    res = await Model().exec(body, token)
+    return res

--- a/apis/routers/endpoints.py
+++ b/apis/routers/endpoints.py
@@ -50,3 +50,9 @@ class GetMessages:
     endpoint = "/getmessages"
     summary = "メッセージの取得"
     description = """メッセージの取得"""
+
+
+class GetCards:
+    endpoint = "/getcards"
+    summary = "カードの取得"
+    description = """カードの取得"""

--- a/apis/routers/endpoints.py
+++ b/apis/routers/endpoints.py
@@ -56,3 +56,9 @@ class GetCards:
     endpoint = "/getcards"
     summary = "カードの取得"
     description = """カードの取得"""
+    
+    
+class GetCategories:
+    endpoint = "/getcategories"
+    summary = "カテゴリの取得"
+    description = """カテゴリの取得"""

--- a/apis/routers/endpoints.py
+++ b/apis/routers/endpoints.py
@@ -68,3 +68,8 @@ class AddCard:
     endpoint = "/addcard"
     summary = "カードの追加"
     description = """カードの追加"""
+
+class AddCategory:
+    endpoint = "/addcategory"
+    summary = "カテゴリの追加"
+    description = """カテゴリの追加"""

--- a/apis/routers/endpoints.py
+++ b/apis/routers/endpoints.py
@@ -56,9 +56,15 @@ class GetCards:
     endpoint = "/getcards"
     summary = "カードの取得"
     description = """カードの取得"""
-    
-    
+
+
 class GetCategories:
     endpoint = "/getcategories"
     summary = "カテゴリの取得"
     description = """カテゴリの取得"""
+
+
+class AddCard:
+    endpoint = "/addcard"
+    summary = "カードの追加"
+    description = """カードの追加"""

--- a/apis/routers/getcards/model.py
+++ b/apis/routers/getcards/model.py
@@ -1,0 +1,32 @@
+from sqlalchemy import and_
+from fastapi import status, HTTPException
+from pydantic import BaseModel
+from .schema import Response, TokenData, Data
+from apis.services.authfunctions import database
+from apis.bases.card import Card
+
+
+class Model(BaseModel):
+    async def exec(self, token: TokenData) -> Response:
+        # loginしていない場合、拒否する。
+        if not token:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+            )
+
+        query = Card.__table__.select()
+        result = await database.fetch_all(query)
+
+        arry = []  # dataリストを初期化
+        for card in result:
+            dt = Data(
+                id=card.id,
+                category_id = card.category_id,
+                color_id = card.color_id,
+                name = card.name,
+                position = card.position,
+                due_date = card.due_date,
+                detail = card.detail
+            )
+            arry.append(dt)
+        return Response(status=1, data=arry)

--- a/apis/routers/getcards/model.py
+++ b/apis/routers/getcards/model.py
@@ -19,7 +19,10 @@ class Model(BaseModel):
 
         arry = []  # dataリストを初期化
         for card in result:
+            # ここでisUserCreatedを設定する。
+            is_user_created = card.uid == token.uid
             dt = Data(
+                isUserCreated=is_user_created,
                 card_id=card.card_id,
                 card_pos = card.card_pos,
                 col_id = card.col_id,

--- a/apis/routers/getcards/model.py
+++ b/apis/routers/getcards/model.py
@@ -20,13 +20,14 @@ class Model(BaseModel):
         arry = []  # dataリストを初期化
         for card in result:
             dt = Data(
-                id=card.id,
-                category_id = card.category_id,
-                color_id = card.color_id,
-                name = card.name,
-                position = card.position,
+                card_id=card.card_id,
+                card_pos = card.card_pos,
+                col_id = card.col_id,
+                card_name = card.card_name,
+                input_date = card.input_date,
                 due_date = card.due_date,
-                detail = card.detail
+                color = card.color,
+                description = card.description
             )
             arry.append(dt)
         return Response(status=1, data=arry)

--- a/apis/routers/getcards/schema.py
+++ b/apis/routers/getcards/schema.py
@@ -1,0 +1,72 @@
+from pydantic import BaseModel, Field
+from typing import Optional, List
+from datetime import date
+
+
+class TokenData(BaseModel):
+    data: str = Field(..., title="デコードされたtoken", description="cookieから取得したtoken一式")
+#サンプルから変更なし
+
+class Data(BaseModel):
+    id: int = Field(..., title="カードid", description="カードのID")
+    category_id: int = Field(..., title="カテゴリid", description="カテゴリのid")
+    color_id: int = Field(..., title="色id", description="色のid")
+    name: str = Field(..., title="カード名", description="カードの名前(タスク名)")
+    due_date: date = Field(..., title="期限", description="タスクの期限")
+    position: int = Field(..., title="カードの位置", description="カードの位置を示す番号")
+    detail: str = Field(None, title="カードの説明", description="掲示板やチャットルームの説明")
+#sqlalchemyの定義（card.pyのCardクラス）と平仄をとり定義
+
+
+class Response(BaseModel):
+    status: int = Field(
+        ...,
+        title="ステータス",
+        description="正しい場合1、不正の場合0",
+    )
+    data: Optional[List[Data]] = Field(
+        None, title="カード情報リスト", description="カードid、カテゴリid、色id、カード名、期限、カードの位置、カードの説明"
+    )
+
+
+ResponseExamples = {
+    200: {
+        "description": "Success results must be list.",
+        "content": {
+            "application/json": {
+                "examples": {
+                    "success": {
+                        "summary": "クエリリクエスト成功",
+                        "value": {
+                            "status": 1,
+                            "results": [
+                                {
+                                    "id": 1,
+                                    "category_id": 1,
+                                    "color_id": 1,
+                                    "name": "ハッカソン中間発表資料作成",
+                                    "position": 1,
+                                    "due_date": "2024-03-01",
+                                    "detail": "Canvaを用いて作成する"
+                                },
+                                {
+                                    "id": 2,
+                                    "category_id": 1,
+                                    "color_id": 1,
+                                    "name": "基本情報の過去問を解く",
+                                    "position": 2,
+                                    "due_date": "2024-04-01",
+                                    "detail": "参考書を一通り終わらせる"
+                                },
+                            ],
+                        },
+                    },
+                    "error": {
+                        "summary": "クエリリクエスト失敗",
+                        "value": {"status": 0, "results": []},
+                    },
+                }
+            }
+        },
+    }
+}

--- a/apis/routers/getcards/schema.py
+++ b/apis/routers/getcards/schema.py
@@ -6,8 +6,8 @@ from datetime import date
 class TokenData(BaseModel):
     data: str = Field(..., title="デコードされたtoken", description="cookieから取得したtoken一式")
 
-#更新ここから
 class Data(BaseModel):
+    isUserCreated: bool = Field(..., title="カードの作成者か", description="カードの作成者かどうかの判定")
     card_id: str = Field(..., title="カードid", description="カードのID(ハッシュ値)")
     card_pos: int = Field(..., title="カードの位置", description="カテゴリ内でのカードの位置を示す番号")
     col_id: str = Field(..., title="カテゴリid", description="カテゴリのID(ハッシュ値)")
@@ -16,7 +16,6 @@ class Data(BaseModel):
     due_date: date = Field(..., title="期限", description="タスクの期限")
     color: str = Field(..., title="色id", description="色のid")
     description: str = Field(None, title="カードの説明", description="カードの説明")
-#更新ここまで
 
 class Response(BaseModel):
     status: int = Field(
@@ -29,45 +28,5 @@ class Response(BaseModel):
     )
 
 
-#swaggerUIのドキュメント生成用：あとで必要に応じて更新
-ResponseExamples = {
-    # 200: {
-    #     "description": "Success results must be list.",
-    #     "content": {
-    #         "application/json": {
-    #             "examples": {
-    #                 "success": {
-    #                     "summary": "クエリリクエスト成功",
-    #                     "value": {
-    #                         "status": 1,
-    #                         "results": [
-    #                             {
-    #                                 "id": 1,
-    #                                 "category_id": 1,
-    #                                 "color_id": 1,
-    #                                 "name": "ハッカソン中間発表資料作成",
-    #                                 "position": 1,
-    #                                 "due_date": "2024-03-01",
-    #                                 "detail": "Canvaを用いて作成する"
-    #                             },
-    #                             {
-    #                                 "id": 2,
-    #                                 "category_id": 1,
-    #                                 "color_id": 1,
-    #                                 "name": "基本情報の過去問を解く",
-    #                                 "position": 2,
-    #                                 "due_date": "2024-04-01",
-    #                                 "detail": "参考書を一通り終わらせる"
-    #                             },
-    #                         ],
-    #                     },
-    #                 },
-    #                 "error": {
-    #                     "summary": "クエリリクエスト失敗",
-    #                     "value": {"status": 0, "results": []},
-    #                 },
-    #             }
-    #         }
-    #     },
-    # }
-}
+#あとで必要に応じて作成
+ResponseExamples = {}

--- a/apis/routers/getcards/schema.py
+++ b/apis/routers/getcards/schema.py
@@ -4,7 +4,7 @@ from datetime import date
 
 
 class TokenData(BaseModel):
-    data: str = Field(..., title="デコードされたtoken", description="cookieから取得したtoken一式")
+    uid: str = Field(..., title="デコードされたtoken", description="cookieから取得したtoken一式")
 
 class Data(BaseModel):
     isUserCreated: bool = Field(..., title="カードの作成者か", description="カードの作成者かどうかの判定")

--- a/apis/routers/getcards/schema.py
+++ b/apis/routers/getcards/schema.py
@@ -5,18 +5,18 @@ from datetime import date
 
 class TokenData(BaseModel):
     data: str = Field(..., title="デコードされたtoken", description="cookieから取得したtoken一式")
-#サンプルから変更なし
 
+#更新ここから
 class Data(BaseModel):
-    id: int = Field(..., title="カードid", description="カードのID")
-    category_id: int = Field(..., title="カテゴリid", description="カテゴリのid")
-    color_id: int = Field(..., title="色id", description="色のid")
-    name: str = Field(..., title="カード名", description="カードの名前(タスク名)")
+    card_id: str = Field(..., title="カードid", description="カードのID(ハッシュ値)")
+    card_pos: int = Field(..., title="カードの位置", description="カテゴリ内でのカードの位置を示す番号")
+    col_id: str = Field(..., title="カテゴリid", description="カテゴリのID(ハッシュ値)")
+    card_name: str = Field(..., title="カード名", description="カードの名前(タスク名)")
+    input_date: date = Field(..., title="作成日", description="カードの作成日")
     due_date: date = Field(..., title="期限", description="タスクの期限")
-    position: int = Field(..., title="カードの位置", description="カードの位置を示す番号")
-    detail: str = Field(None, title="カードの説明", description="掲示板やチャットルームの説明")
-#sqlalchemyの定義（card.pyのCardクラス）と平仄をとり定義
-
+    color: str = Field(..., title="色id", description="色のid")
+    description: str = Field(None, title="カードの説明", description="カードの説明")
+#更新ここまで
 
 class Response(BaseModel):
     status: int = Field(
@@ -25,48 +25,49 @@ class Response(BaseModel):
         description="正しい場合1、不正の場合0",
     )
     data: Optional[List[Data]] = Field(
-        None, title="カード情報リスト", description="カードid、カテゴリid、色id、カード名、期限、カードの位置、カードの説明"
+        None, title="カード情報リスト"
     )
 
 
+#swaggerUIのドキュメント生成用：あとで必要に応じて更新
 ResponseExamples = {
-    200: {
-        "description": "Success results must be list.",
-        "content": {
-            "application/json": {
-                "examples": {
-                    "success": {
-                        "summary": "クエリリクエスト成功",
-                        "value": {
-                            "status": 1,
-                            "results": [
-                                {
-                                    "id": 1,
-                                    "category_id": 1,
-                                    "color_id": 1,
-                                    "name": "ハッカソン中間発表資料作成",
-                                    "position": 1,
-                                    "due_date": "2024-03-01",
-                                    "detail": "Canvaを用いて作成する"
-                                },
-                                {
-                                    "id": 2,
-                                    "category_id": 1,
-                                    "color_id": 1,
-                                    "name": "基本情報の過去問を解く",
-                                    "position": 2,
-                                    "due_date": "2024-04-01",
-                                    "detail": "参考書を一通り終わらせる"
-                                },
-                            ],
-                        },
-                    },
-                    "error": {
-                        "summary": "クエリリクエスト失敗",
-                        "value": {"status": 0, "results": []},
-                    },
-                }
-            }
-        },
-    }
+    # 200: {
+    #     "description": "Success results must be list.",
+    #     "content": {
+    #         "application/json": {
+    #             "examples": {
+    #                 "success": {
+    #                     "summary": "クエリリクエスト成功",
+    #                     "value": {
+    #                         "status": 1,
+    #                         "results": [
+    #                             {
+    #                                 "id": 1,
+    #                                 "category_id": 1,
+    #                                 "color_id": 1,
+    #                                 "name": "ハッカソン中間発表資料作成",
+    #                                 "position": 1,
+    #                                 "due_date": "2024-03-01",
+    #                                 "detail": "Canvaを用いて作成する"
+    #                             },
+    #                             {
+    #                                 "id": 2,
+    #                                 "category_id": 1,
+    #                                 "color_id": 1,
+    #                                 "name": "基本情報の過去問を解く",
+    #                                 "position": 2,
+    #                                 "due_date": "2024-04-01",
+    #                                 "detail": "参考書を一通り終わらせる"
+    #                             },
+    #                         ],
+    #                     },
+    #                 },
+    #                 "error": {
+    #                     "summary": "クエリリクエスト失敗",
+    #                     "value": {"status": 0, "results": []},
+    #                 },
+    #             }
+    #         }
+    #     },
+    # }
 }

--- a/apis/routers/getcards/view.py
+++ b/apis/routers/getcards/view.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends, status
+from apis.services.authfunctions import get_current_user
+from .schema import Response, ResponseExamples, TokenData
+from .model import Model
+from ..endpoints import GetCards as ep
+
+router = APIRouter()
+
+
+# cookieをsetするJSONResponseはPydanticのBaseModelと共存できないので、response_modelを使えない。
+# またrequest_modelも事前にリクエストヘッダからcookieを読むので、使わない。
+@router.get(
+    ep.endpoint,
+    summary=ep.summary,
+    description=ep.description,
+    status_code=status.HTTP_200_OK,
+    response_model=Response,
+    responses=ResponseExamples,
+    response_model_exclude_unset=True,
+    response_model_exclude_none=True,
+)
+async def get_payloads(token: TokenData = Depends(get_current_user)):
+    res = await Model().exec(token)
+    return res

--- a/apis/routers/getcategories/model.py
+++ b/apis/routers/getcategories/model.py
@@ -3,7 +3,7 @@ from fastapi import status, HTTPException
 from pydantic import BaseModel
 from .schema import Response, TokenData, Data
 from apis.services.authfunctions import database
-from apis.bases.card import Category
+from apis.bases.category import Category
 
 
 class Model(BaseModel):
@@ -19,7 +19,10 @@ class Model(BaseModel):
 
         arry = []  # dataリストを初期化
         for category in result:
+            # ここでisUserCreatedを設定する。
+            is_user_created = category.uid == token.uid
             dt = Data(
+                isUserCreated=is_user_created,
                 col_id = category.col_id,
                 col_pos = category.col_pos,
                 col_name = category.col_name,

--- a/apis/routers/getcategories/model.py
+++ b/apis/routers/getcategories/model.py
@@ -1,0 +1,29 @@
+from sqlalchemy import and_
+from fastapi import status, HTTPException
+from pydantic import BaseModel
+from .schema import Response, TokenData, Data
+from apis.services.authfunctions import database
+from apis.bases.card import Category
+
+
+class Model(BaseModel):
+    async def exec(self, token: TokenData) -> Response:
+        # loginしていない場合、拒否する。
+        if not token:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+            )
+
+        query = Category.__table__.select()
+        result = await database.fetch_all(query)
+
+        arry = []  # dataリストを初期化
+        for category in result:
+            dt = Data(
+                col_id = category.col_id,
+                col_pos = category.col_pos,
+                col_name = category.col_name,
+                description = category.description
+            )
+            arry.append(dt)
+        return Response(status=1, data=arry)

--- a/apis/routers/getcategories/schema.py
+++ b/apis/routers/getcategories/schema.py
@@ -5,13 +5,12 @@ from typing import Optional, List
 class TokenData(BaseModel):
     data: str = Field(..., title="デコードされたtoken", description="cookieから取得したtoken一式")
 
-#更新ここから
 class Data(BaseModel):
+    isUserCreated: bool = Field(..., title="カードの作成者か", description="カードの作成者かどうかの判定")
     col_id: str = Field(..., title="カテゴリid", description="カテゴリのID(ハッシュ値)")
     col_pos: int = Field(..., title="カテゴリの位置", description="カテゴリの位置を示す番号")
     col_name: str = Field(..., title="カテゴリ名", description="カテゴリの名前(未着手／完了などのステータス名)")
     description: str = Field(None, title="カードの説明", description="カードの説明")
-#更新ここまで
 
 class Response(BaseModel):
     status: int = Field(
@@ -24,45 +23,5 @@ class Response(BaseModel):
     )
 
 
-#swaggerUIのドキュメント生成用：あとで必要に応じて更新
-ResponseExamples = {
-    # 200: {
-    #     "description": "Success results must be list.",
-    #     "content": {
-    #         "application/json": {
-    #             "examples": {
-    #                 "success": {
-    #                     "summary": "クエリリクエスト成功",
-    #                     "value": {
-    #                         "status": 1,
-    #                         "results": [
-    #                             {
-    #                                 "id": 1,
-    #                                 "category_id": 1,
-    #                                 "color_id": 1,
-    #                                 "name": "ハッカソン中間発表資料作成",
-    #                                 "position": 1,
-    #                                 "due_date": "2024-03-01",
-    #                                 "detail": "Canvaを用いて作成する"
-    #                             },
-    #                             {
-    #                                 "id": 2,
-    #                                 "category_id": 1,
-    #                                 "color_id": 1,
-    #                                 "name": "基本情報の過去問を解く",
-    #                                 "position": 2,
-    #                                 "due_date": "2024-04-01",
-    #                                 "detail": "参考書を一通り終わらせる"
-    #                             },
-    #                         ],
-    #                     },
-    #                 },
-    #                 "error": {
-    #                     "summary": "クエリリクエスト失敗",
-    #                     "value": {"status": 0, "results": []},
-    #                 },
-    #             }
-    #         }
-    #     },
-    # }
-}
+#swaggerUIのドキュメント生成用：あとで必要に応じて作成
+ResponseExamples = {}

--- a/apis/routers/getcategories/schema.py
+++ b/apis/routers/getcategories/schema.py
@@ -1,0 +1,68 @@
+from pydantic import BaseModel, Field
+from typing import Optional, List
+
+
+class TokenData(BaseModel):
+    data: str = Field(..., title="デコードされたtoken", description="cookieから取得したtoken一式")
+
+#更新ここから
+class Data(BaseModel):
+    col_id: str = Field(..., title="カテゴリid", description="カテゴリのID(ハッシュ値)")
+    col_pos: int = Field(..., title="カテゴリの位置", description="カテゴリの位置を示す番号")
+    col_name: str = Field(..., title="カテゴリ名", description="カテゴリの名前(未着手／完了などのステータス名)")
+    description: str = Field(None, title="カードの説明", description="カードの説明")
+#更新ここまで
+
+class Response(BaseModel):
+    status: int = Field(
+        ...,
+        title="ステータス",
+        description="正しい場合1、不正の場合0",
+    )
+    data: Optional[List[Data]] = Field(
+        None, title="カテゴリ情報リスト"
+    )
+
+
+#swaggerUIのドキュメント生成用：あとで必要に応じて更新
+ResponseExamples = {
+    # 200: {
+    #     "description": "Success results must be list.",
+    #     "content": {
+    #         "application/json": {
+    #             "examples": {
+    #                 "success": {
+    #                     "summary": "クエリリクエスト成功",
+    #                     "value": {
+    #                         "status": 1,
+    #                         "results": [
+    #                             {
+    #                                 "id": 1,
+    #                                 "category_id": 1,
+    #                                 "color_id": 1,
+    #                                 "name": "ハッカソン中間発表資料作成",
+    #                                 "position": 1,
+    #                                 "due_date": "2024-03-01",
+    #                                 "detail": "Canvaを用いて作成する"
+    #                             },
+    #                             {
+    #                                 "id": 2,
+    #                                 "category_id": 1,
+    #                                 "color_id": 1,
+    #                                 "name": "基本情報の過去問を解く",
+    #                                 "position": 2,
+    #                                 "due_date": "2024-04-01",
+    #                                 "detail": "参考書を一通り終わらせる"
+    #                             },
+    #                         ],
+    #                     },
+    #                 },
+    #                 "error": {
+    #                     "summary": "クエリリクエスト失敗",
+    #                     "value": {"status": 0, "results": []},
+    #                 },
+    #             }
+    #         }
+    #     },
+    # }
+}

--- a/apis/routers/getcategories/schema.py
+++ b/apis/routers/getcategories/schema.py
@@ -3,14 +3,14 @@ from typing import Optional, List
 
 
 class TokenData(BaseModel):
-    data: str = Field(..., title="デコードされたtoken", description="cookieから取得したtoken一式")
+    uid: str = Field(..., title="デコードされたtoken", description="cookieから取得したtoken一式")
 
 class Data(BaseModel):
-    isUserCreated: bool = Field(..., title="カードの作成者か", description="カードの作成者かどうかの判定")
+    isUserCreated: bool = Field(..., title="カテゴリの作成者か", description="カテゴリの作成者かどうかの判定")
     col_id: str = Field(..., title="カテゴリid", description="カテゴリのID(ハッシュ値)")
     col_pos: int = Field(..., title="カテゴリの位置", description="カテゴリの位置を示す番号")
     col_name: str = Field(..., title="カテゴリ名", description="カテゴリの名前(未着手／完了などのステータス名)")
-    description: str = Field(None, title="カードの説明", description="カードの説明")
+    description: str = Field(None, title="カテゴリの説明", description="カテゴリの説明")
 
 class Response(BaseModel):
     status: int = Field(

--- a/apis/routers/getcategories/view.py
+++ b/apis/routers/getcategories/view.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends, status
+from apis.services.authfunctions import get_current_user
+from .schema import Response, ResponseExamples, TokenData
+from .model import Model
+from ..endpoints import GetCategories as ep
+
+router = APIRouter()
+
+
+# cookieをsetするJSONResponseはPydanticのBaseModelと共存できないので、response_modelを使えない。
+# またrequest_modelも事前にリクエストヘッダからcookieを読むので、使わない。
+@router.get(
+    ep.endpoint,
+    summary=ep.summary,
+    description=ep.description,
+    status_code=status.HTTP_200_OK,
+    response_model=Response,
+    responses=ResponseExamples,
+    response_model_exclude_unset=True,
+    response_model_exclude_none=True,
+)
+async def get_payloads(token: TokenData = Depends(get_current_user)):
+    res = await Model().exec(token)
+    return res


### PR DESCRIPTION
Category,Cardテーブルの作成＋汎用性のありそうなAPIの作成。
swaggerUIにてexamplevalueで一通りの動作確認はしています。

APIについて
①addcategory：カテゴリ情報のDBへの登録（ログイン中のユーザidもあわせて登録）
②addcard：カード情報のDBへの登録（ログイン中のユーザidもあわせて登録）
③getcategories：カテゴリ情報のDBからの取得（ログイン中のユーザが作成したものかについてのbool値も返す）
④getcards：カード情報のDBからの取得（ログイン中のユーザが作成したものかについてのbool値も返す）