### PR TITLE
add cryptography to login AWS RDS

### DIFF
--- a/apis/requirements.txt
+++ b/apis/requirements.txt
@@ -7,3 +7,4 @@ passlib
 databases
 aiomysql
 python-jose
+cryptography


### PR DESCRIPTION
AWSのRDSにログインしようとするとrequirement.txtにcryptographyが必要だった。